### PR TITLE
Fixed hard-coded header frame id in a pose message of the topic waypoints

### DIFF
--- a/src/follow_waypoints/follow_waypoints.py
+++ b/src/follow_waypoints/follow_waypoints.py
@@ -44,7 +44,7 @@ class FollowPath(State):
 def convert_PoseWithCovArray_to_PoseArray(waypoints):
     """Used to publish waypoints as pose array so that you can see them in rviz, etc."""
     poses = PoseArray()
-    poses.header.frame_id = 'map'
+    poses.header.frame_id = rospy.get_param('~goal_frame_id','map')
     poses.poses = [pose.pose.pose for pose in waypoints]
     return poses
 


### PR DESCRIPTION
The pose array message topic /waypoints stores poses sent from /initialpose.

When storing a pose, the callback set a hard coded frame ID 'map'. Instead, it should set a goal_frame_id from the rosparam. 