### PR TITLE
Make waypoint_distance_tolerance as private params

### DIFF
--- a/src/follow_waypoints/follow_waypoints.py
+++ b/src/follow_waypoints/follow_waypoints.py
@@ -57,7 +57,7 @@ class FollowPath(State):
         rospy.loginfo('Starting a tf listner.')
         self.tf = TransformListener()
         self.listener = tf.TransformListener()
-        self.distance_tolerance = rospy.get_param('waypoint_distance_tolerance', 0.0)
+        self.distance_tolerance = rospy.get_param('~waypoint_distance_tolerance', 0.0)
 
     def execute(self, userdata):
         global waypoints


### PR DESCRIPTION
# What is this?

Make waypoint_distance_tolerance as private params.
This PR unifies parameters as private parameters, as the other parameters are set as private.
https://github.com/iory/follow_waypoints/blob/c5cd4220f3fcc391cfae2e61dbcd196c2e905d3d/src/follow_waypoints/follow_waypoints.py#L48-L51